### PR TITLE
Update recorder.py

### DIFF
--- a/opensrane/Recorders/recorder.py
+++ b/opensrane/Recorders/recorder.py
@@ -299,7 +299,12 @@ class recorder(_NewClass):
 
         #Set the Recorder Counter to zero
         self.AnalyzeCounter=0
-
+    
+    def OtherSaveOnce(self):
+        #Just because such method exist for objs_recorder, so here also should exist to avoid error when calling all objects (For recorder it doesn't do anything
+        pass
+    
+    
     def _Deletefile(self):
         
         files=_os.listdir()


### PR DESCRIPTION
OtherSaveOnce method added because this subpackage does not have _GlobalParameters and so, Because in objs_recorder we have OtherSaveOnce() method so we should have it also here to avoid any error if we call it for all recorder objects.