### PR TITLE
Remove SaveStep to Analyze part

### DIFF
--- a/opensrane/Analyze/ScenarioAnalyze.py
+++ b/opensrane/Analyze/ScenarioAnalyze.py
@@ -159,14 +159,13 @@ class ScenarioAnalyze():
             #Save Other subpackages that aren't defined for objs_recorder (It doesn't have any influence of affect for recordes and is only for objs_recorder.
             [obj.OtherSaveOnce() for obj in _opr.Recorders.ObjManager.Objlst] 
 
-    def MultiParallel(AnalysisNumber=100, NumberOfProcessors=3, RecorderSaveStep=5000, MergeSavedFiles=False):
+    def MultiParallel(AnalysisNumber=100, NumberOfProcessors=3, RecordersSaveStep=5000, MergeSavedFiles=False):
         
         '''
         
         REMEMBER: The only way to use this command is to call it inside "if __name__='__main__': " 
         
-        RecorderSaveStep: if user didn't define Objs_recorder then the RecorderSaveStep will be use as save step But_
-                          if Objs_recorder were define its save step will be consider as savestep
+        RecordersSaveStep: RecordersSaveStep will be use as save step.
                           
         MergeSavedFiles: If set this option into True, When analysis finished all files will be merge into one file and for huge files it take so_
                          much memory and time!
@@ -184,15 +183,7 @@ class ScenarioAnalyze():
                 if obj.fileAppend==False:
                     obj.fileAppend==True
                     obj._ResetRecorder()   
-                    
-        MaxExistSavedfileIndex=obj.MaxExistSavedfileIndex
 
-        #Set SaveStep
-        SaveStep=None
-        for obj in _opr.Recorders.ObjManager.Objlst:
-            if obj.__class__.__name__=='Objs_recorder':
-                SaveStep=int(obj.SaveStep)
-                break
         
         #Check Number of CPUs        
         NOP=_mp.cpu_count()
@@ -201,7 +192,7 @@ class ScenarioAnalyze():
             NOP=NumberOfProcessors
         
         #Set the save step:
-        if SaveStep==None: SaveStep=int(RecorderSaveStep)
+        SaveStep=int(RecordersSaveStep)
 
         #Set Number of Analysis for each CPU
         AnalyzeList=AnalysisNumber/SaveStep if AnalysisNumber%SaveStep==0 else int(AnalysisNumber/SaveStep)+1
@@ -212,7 +203,7 @@ class ScenarioAnalyze():
         
         #Set Analyze
         print('Analysis Number of each core: ',AnalyzeList)
-        pool.starmap(_opr.Analyze.ScenarioAnalyze.MultiAnalysis, [(AnalyseNumber,True,fileindex+MaxExistSavedfileIndex+1) for fileindex,AnalyseNumber in enumerate(AnalyzeList)])
+        pool.starmap(_opr.Analyze.ScenarioAnalyze.MultiAnalysis, [(AnalyseNumber,True,fileindex+1) for fileindex,AnalyseNumber in enumerate(AnalyzeList)])
         
         pool.close()
 

--- a/opensrane/Recorders/Objs_recorder.py
+++ b/opensrane/Recorders/Objs_recorder.py
@@ -46,13 +46,13 @@ class Objs_recorder(_NewClass):
     This Object id for recording all of the objects in each scenario analysis
     tag= tag of the recorder
     filename: name of the file that data will be record in it
-    SaveStep: Number of the steps of analysis that after that, data will be record on a file
+    SaveStep: It was the Number of the steps of analysis that after that, data will be record on a file but it removed from objects and it is sent to analyze part. It is set to None because for preventing any error of using old created models.
     fileAppend: Does data append to a existing file or it reset existing data in the file name
     RecodingSubpackages: List of subpackages that Users wanna to be record by recorders. The default value is ['PlantUnits','Hazard', 'DateAndTime', 'WindData'] but others also can be added by user except 'Recorders'. The Other subpackages will be record once at the first savefile. 
     
     '''
     
-    def __init__(self,tag,filename='',SaveStep=100,fileAppend=True, RecodingSubpackages=['PlantUnits', 'Hazard', 'DateAndTime', 'WindData', 'NodesGroups']):
+    def __init__(self,tag,filename='',fileAppend=True, RecodingSubpackages=['PlantUnits', 'Hazard', 'DateAndTime', 'WindData', 'NodesGroups'],SaveStep=None):
          
         #---- Fix Part for each class __init__ ----
         ObjManager.Add(tag,self)
@@ -60,7 +60,6 @@ class Objs_recorder(_NewClass):
         #------------------------------------------
         
         self.filename=filename
-        self.SaveStep=SaveStep
         self.fileAppend=fileAppend
         
         if fileAppend==False:
@@ -97,7 +96,6 @@ class Objs_recorder(_NewClass):
         '''
 
         self.RecordCounter +=1
-        SaveStep=int(self.SaveStep)
 
         #If there is any damage then the data will be recorded
         if _opr.Analyze.ScenarioAnalyze.anydamage==True:
@@ -114,8 +112,11 @@ class Objs_recorder(_NewClass):
         return 0
 
     def SaveToFile(self,fileindex):
+        
+        #fileindex are from 0 to number of files. If user wanna to append the existing files then the maximum index number of existing files should be added to input fileindex
+        fileindex=fileindex+self.MaxExistSavedfileIndex
 
-            
+        
         #Create log file to record number of the analysis
         with open(self.filename+str(fileindex)+'.Log', "w") as f:
             f.write(f'Number of Analysis: {self.RecordCounter}\nNumber of Scenarios in this log: {len(self.RecordedList)}')


### PR DESCRIPTION
Because of parallel issues and because in this analysis all recorders have to have unique savestep this option removed from recorder objects and added to MultiParallel of analysis subpackage